### PR TITLE
Fix _append_to_path

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -146,7 +146,7 @@ _prepend_to_path() {
 
 _append_to_path() {
   if [ -d $1 -a -z ${path[(r)$1]} ]; then
-    path=($1 $path);
+    path=($path $1);
   fi
 }
 


### PR DESCRIPTION
It looks like `_prepend_to_path` and `_append_to_path` are doing the same thing. This PR should sort it.

---

I loooooooove your path modifying functions. I've always hated having to manage the PATH and worry about duplicating stuff.

If you don't mind, my script-fu is decent but I would love a little breakdown of how it's only adding if it doesn't already exist.