### PR TITLE
Call ModuleSkipHandle to ModuleSkipRenamerHandle

### DIFF
--- a/.emacs.d/python/rope/refactor/move.py
+++ b/.emacs.d/python/rope/refactor/move.py
@@ -610,7 +610,7 @@ class ModuleSkipRenamer(object):
         self.replacement = replacement
         self.handle = handle
         if self.handle is None:
-            self.handle = ModuleSkipHandle()
+            self.handle = ModuleSkipRenamerHandle()
 
     def get_changed_module(self):
         source = self.resource.read()


### PR DESCRIPTION
ModuleSkipHandle is an undefined name in this context that can raise NameError at runtime.