### PR TITLE
Read an optional .config file, to set relevant variables

### DIFF
--- a/.vim/update.sh
+++ b/.vim/update.sh
@@ -4,8 +4,9 @@
 #
 # Specify [pattern] to update only repos that match the pattern.
 
-if [ -f ../.config ]; then
-  source ../.config
+scriptdir=$(dirname $0)
+if [ -f ${scriptdir}/../.config ]; then
+  source ${scriptdir}/../.config
 fi
 
 

--- a/.vim/update.sh
+++ b/.vim/update.sh
@@ -43,7 +43,7 @@ default_repos=(
 
 )
 
-repos=${vim_plugins_github:-$default_repos}
+repos=${vim_plugins_github[@]:-$default_repos[@]}
 
 set -e
 dir=${installdir:-$HOME}/.vim/bundle

--- a/.vim/update.sh
+++ b/.vim/update.sh
@@ -4,7 +4,12 @@
 #
 # Specify [pattern] to update only repos that match the pattern.
 
-repos=(
+if [ -f ../.config ]; then
+  source ../.config
+fi
+
+
+default_repos=(
 
   airblade/vim-gitgutter
   alampros/vim-styled-jsx
@@ -38,8 +43,10 @@ repos=(
 
 )
 
+repos=${vim_plugins_github:-$default_repos}
+
 set -e
-dir=~/.dotfiles/.vim/bundle
+dir=${installdir}/.vim/bundle
 
 if [ -d $dir -a -z "$1" ]; then
   temp="$(mktemp -d -t bundleXXXXX)"

--- a/.vim/update.sh
+++ b/.vim/update.sh
@@ -46,7 +46,7 @@ default_repos=(
 repos=${vim_plugins_github:-$default_repos}
 
 set -e
-dir=${installdir}/.vim/bundle
+dir=${installdir:-$HOME}/.vim/bundle
 
 if [ -d $dir -a -z "$1" ]; then
   temp="$(mktemp -d -t bundleXXXXX)"

--- a/install.sh
+++ b/install.sh
@@ -4,9 +4,15 @@
 
 set -e
 
-basedir=$HOME/.dotfiles
-bindir=$HOME/bin
-repourl=git://github.com/statico/dotfiles.git
+config_dir=$(dirname $0)
+if [ -f "${config_dir}/.config" ]; then
+  source ${config_dir}/.config
+fi
+
+basedir=${basedir:-$HOME/.dotfiles}
+repourl=${repourl:-git://github.com/statico/dotfiles.git}
+installdir=${installdir:-$HOME}
+bindir=${bindir:-$installdir/bin}
 
 function symlink() {
   src=$1
@@ -54,12 +60,12 @@ for path in .* ; do
       continue
       ;;
     *)
-      symlink $basedir/$path $HOME/$path
+      symlink $basedir/$path $installdir/$path
       ;;
   esac
 done
-symlink $basedir/.vim/vimrc $HOME/.vimrc
-symlink $basedir/.vim/gvimrc $HOME/.gvimrc
+symlink $basedir/.vim/vimrc $installdir/.vimrc
+symlink $basedir/.vim/gvimrc $installdir/.gvimrc
 
 echo "Adding executables to ~/bin/..."
 mkdir -p $bindir
@@ -68,10 +74,12 @@ for path in bin/* ; do
 done
 
 echo "Setting up vim plugins..."
-.vim/update.sh
+if [ -x .vim/update.sh ]; then
+  .vim/update.sh
+fi
 
 echo "Setting up git..."
-cp $basedir/.gitconfig.base $HOME/.gitconfig
+cp $basedir/.gitconfig.base $installdir/.gitconfig
 
 postinstall=$HOME/.postinstall
 if [ -e $postinstall ]; then


### PR DESCRIPTION
allows for easier customization of statico's install script, so users can override the default values for `repourl`, `basedir`, `bindir`.
Also makes for easier testing, using `installdir` instead of `$HOME`.

i used a `.config` like this to test:
```
repourl=https://github.com/muncus/dotfiles.git
basedir=`mktemp -dt dotfiles_repo.XXXXX`
installdir=`mktemp -dt dotfiles_install.XXXXX`
```